### PR TITLE
Radio button support fix in Form component

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Need a patched version of Dash for now
-#dash>=1.2.0
+dash>=1.2.0
 #-e "D:\src\python\dash-dev\other\dash"
-https://github.com/stevej2608/dash/archive/stevej2608.zip
+# https://github.com/stevej2608/dash/archive/stevej2608.zip
 
 dash-bootstrap-components>=0.7.1
 pyyaml>=5.1.2

--- a/src/components/Form.react.js
+++ b/src/components/Form.react.js
@@ -11,7 +11,7 @@ class Form extends Component {
   constructor(props) {
     super(props);
     this.handleSubmit = this.handleSubmit.bind(this);
-   }
+  }
 
   /**
    * Iterate over form fields
@@ -21,18 +21,25 @@ class Form extends Component {
 
   getFormFields(elements) {
     const obj = {}
-    for(let i = 0 ; i < elements.length ; i++){
-      const item  = elements.item(i);
+    for (let i = 0; i < elements.length; i++) {
+
+      const item = elements.item(i);
 
       if (!item) continue;
-  
+
       if (item.type === 'checkbox') {
         obj[item.id] = item.checked;
         continue;
       }
-  
+
+      if (item.type === 'radio') {
+        if (item.checked) obj[item.name] = item.value;
+        continue;
+      }
+
       if (item.name) obj[item.name] = item.value;
     }
+    
     return obj;
   }
 
@@ -42,14 +49,14 @@ class Form extends Component {
    * @param e 
    */
 
-  handleSubmit(e)  {
+  handleSubmit(e) {
     if (this.props.preventDefault) e.preventDefault();
     const form_data = this.getFormFields(e.currentTarget.elements);
-    this.props.setProps({form_data})
+    this.props.setProps({ form_data })
   }
- 
+
   render() {
-    const { children, loading_state,  ...otherProps } = this.props;
+    const { children, loading_state, ...otherProps } = this.props;
     return (
       <form
         {...otherProps}


### PR DESCRIPTION
Hi Steve.
I realised that Form component in your library is not properly handle radio buttons. So I introduced very small fixed (basically this is is):

if (item.type === 'radio') {
        if (item.checked) obj[item.name] = item.value;
        continue;
        
It would be great if you would merge PR and create new release for this Dash library - it's really very usable, thx for you efforts.